### PR TITLE
Fix update time

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -16,7 +16,9 @@ const Contact = () => {
         <a href="https://twitter.com/_sono_8_">@_sono_8_</a>
       </p>
       <Header as="h3">
-        <a href="https://github.com/sono8stream/codeforces-anytime">Github repository</a>
+        <a href="https://github.com/sono8stream/codeforces-anytime">
+          Github repository
+        </a>
       </Header>
     </>
   );


### PR DESCRIPTION
## Context & Motivation

- 終了していないコンテストの順位でレート変動してしまう

## Document

- コンテストの順位を取得する際に終了日時を計算し，まだ終わっていない場合は除外する
- レートの更新日を最近レート変動したコンテストの終了日時に設定