### PR TITLE
レート更新時にユーザーリストに反映されない

### DIFF
--- a/src/api/fetchRealRating.ts
+++ b/src/api/fetchRealRating.ts
@@ -6,7 +6,7 @@ export const fetchRealRating = async (handle: string): Promise<number> => {
     if (handle !== json.result[0].handle) {
       return -1;
     }
-    return json.result[0].rating;
+    return json.result[0].rating || 1500;
   } catch (e) {
     return -1;
   }

--- a/src/components/ContestsPage.tsx
+++ b/src/components/ContestsPage.tsx
@@ -51,7 +51,7 @@ const ContestsPage: React.FC = () => {
   return (
     <>
       <Header as="h2" content="Supported contests" />
-      <Table celled={true}>
+      <Table unstackable={true} celled={true}>
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>Contest</Table.HeaderCell>

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -223,7 +223,7 @@ const ProfilePage: React.FC = () => {
           <Scatter name="A school" data={data} line={true} fill="white" />
         </ScatterChart>
       </ResponsiveContainer>
-      <Table celled={true}>
+      <Table unstackable={true} celled={true}>
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>Date</Table.HeaderCell>

--- a/src/components/RankingPage.tsx
+++ b/src/components/RankingPage.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
 import { Header, Table } from 'semantic-ui-react';
 import { fetchUsers } from '../actions';
 import { useUsers } from '../hooks';
 import getRatingColorStyle from '../utils/getRatingColorStyle';
-import { Link } from 'react-router-dom';
 
 const RankingPage: React.FC = () => {
   const dispatch = useDispatch();
@@ -19,7 +19,7 @@ const RankingPage: React.FC = () => {
   return (
     <>
       <Header as="h2" content="Ranking" />
-      <Table celled={true}>
+      <Table unstackable={true} celled={true}>
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>Rank</Table.HeaderCell>

--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 import { Button, Header, Icon, List, Loader, Segment } from 'semantic-ui-react';
 import { login } from '../actions';
 import firebase from '../firebase';
 import { useAccountInfo } from '../hooks';
-import { Link, useHistory, useLocation } from 'react-router-dom';
 
 const StartPage: React.FC = () => {
   const history = useHistory();
@@ -125,6 +125,14 @@ const StartPage: React.FC = () => {
         </List.Item>
         <List.Item>
           {isEnglish ? (
+            <>Create user by specifying your user name in Codeforces</>
+          ) : (
+            <>Codeforcesのユーザー名を指定してユーザー登録</>
+          )}
+        </List.Item>
+
+        <List.Item>
+          {isEnglish ? (
             <>
               Enter a{' '}
               <a href="https://codeforces.com" target="blank">
@@ -212,6 +220,29 @@ const StartPage: React.FC = () => {
             ) : (
               <>
                 レート更新処理では，1コンテストあたり30秒前後の計算時間が発生します
+              </>
+            )}
+          </List.Item>
+          <List.Item>
+            {isEnglish ? (
+              <>
+                Virtual contests that you joined before creating user in this
+                service is not rated.
+              </>
+            ) : (
+              <>
+                このサービスでユーザー登録するよりも前に参加したVirtual
+                Contestの結果は無効です
+              </>
+            )}
+          </List.Item>
+          <List.Item>
+            {isEnglish ? (
+              <>To be ranked, you have to join at least one virtual contest</>
+            ) : (
+              <>
+                ランキングに掲載されるには，Virtual
+                Contestの結果を1回以上反映させる必要があります
               </>
             )}
           </List.Item>

--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -238,11 +238,14 @@ const StartPage: React.FC = () => {
           </List.Item>
           <List.Item>
             {isEnglish ? (
-              <>To be ranked, you have to join at least one virtual contest</>
+              <>
+                To be ranked, you have to join at least one virtual contest and
+                update your rating
+              </>
             ) : (
               <>
                 ランキングに掲載されるには，Virtual
-                Contestの結果を1回以上反映させる必要があります
+                Contestの結果を1つ以上反映させる必要があります
               </>
             )}
           </List.Item>

--- a/src/components/UpdateProfilePage.tsx
+++ b/src/components/UpdateProfilePage.tsx
@@ -1,14 +1,15 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useHistory, useLocation } from 'react-router';
 import { Button, Dimmer, Form, Header, Loader, Modal } from 'semantic-ui-react';
 import { updateProfile } from '../actions';
 import { fetchRealRating } from '../api/fetchRealRating';
 import { useAccountInfo, useProfile } from '../hooks';
 import getRatingColorStyle from '../utils/getRatingColorStyle';
-import { useHistory } from 'react-router';
 
 const UpdateProfilePage: React.FC = () => {
   const history = useHistory();
+  const queryParams = new URLSearchParams(useLocation().search);
 
   const dispatch = useDispatch();
   const account = useAccountInfo();
@@ -19,6 +20,13 @@ const UpdateProfilePage: React.FC = () => {
   const [modalOpen, setModalOpen] = useState(false);
   const [handleValidity, setHandleValidity] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
+  const [isEnglish, setIsEnglish] = useState(false);
+
+  useEffect(() => {
+    if (queryParams.get('lang')) {
+      setIsEnglish(queryParams.get('lang') === 'en');
+    }
+  }, []);
 
   const onButtonClick = useCallback(async () => {
     setIsLoading(true);
@@ -75,22 +83,59 @@ const UpdateProfilePage: React.FC = () => {
   }
 
   return (
-    <div>
+    <>
+      <Button.Group floated="right">
+        <Button
+          compact={true}
+          positive={!isEnglish}
+          onClick={() => {
+            if (isEnglish) {
+              setIsEnglish(false);
+            }
+          }}
+        >
+          JP
+        </Button>
+        <Button.Or />
+        <Button
+          compact={true}
+          positive={isEnglish}
+          onClick={() => {
+            if (!isEnglish) {
+              setIsEnglish(true);
+            }
+          }}
+        >
+          EN
+        </Button>
+      </Button.Group>
       <Header
         as="h2"
         content="Update Profile"
-        subheader="使用するCodeforcesのハンドルを設定します．"
+        subheader={
+          isEnglish
+            ? 'Specify your user name in Codeforces'
+            : '使用するCodeforcesのハンドルを設定します．'
+        }
       />
       <Form>
         <Form.Input
           fluid={true}
-          error={!handleValidity}
+          error={
+            handleValidity
+              ? false
+              : { content: 'Invalid user name!', pointing: 'above' }
+          }
           label="Handle"
           value={handle}
           onChange={(e) => setHandle(e.target.value)}
         />
         <Form.Checkbox
-          label="本来のレートを引き継ぐ"
+          label={
+            isEnglish
+              ? 'I take over official rating in Codeforces'
+              : '本来のレートを引き継ぐ'
+          }
           checked={extendRating}
           onClick={(e) => setExtendRating(!extendRating)}
         />
@@ -111,7 +156,13 @@ const UpdateProfilePage: React.FC = () => {
           Cancel
         </Form.Button>
         <Modal open={modalOpen} onClose={() => setModalOpen(false)}>
-          <Modal.Header content="以下の内容で登録" />
+          <Modal.Header
+            content={
+              isEnglish
+                ? 'Create user with the following information'
+                : '以下の内容で登録'
+            }
+          />
           <Modal.Content>
             <Header as="h3" dividing={true}>
               Handle
@@ -128,7 +179,9 @@ const UpdateProfilePage: React.FC = () => {
           </Modal.Content>
           <Modal.Actions>
             <Header as="h5" color="red" floated="left">
-              ！このサービスにおけるこれまでの参加履歴は削除されます
+              {isEnglish
+                ? '! All your records in this service will be deleted!'
+                : '！このサービスにおけるこれまでの参加履歴は削除されます'}
             </Header>
             <Button color="green" onClick={onModalButtonClick}>
               OK
@@ -142,7 +195,7 @@ const UpdateProfilePage: React.FC = () => {
           <Loader active={true} inline="centered" />
         </Dimmer>
       </Form>
-    </div>
+    </>
   );
 };
 

--- a/tslint.json
+++ b/tslint.json
@@ -5,10 +5,11 @@
     "prettier": true,
     "interface-name": false,
     "import-name": false,
-    "no-empty-interface": false,
     "no-console": false,
+    "no-empty": false,
+    "no-empty-interface": false,
     "object-literal-sort-keys": false,
-    "jsx-no-lambda": false,
-    "no-empty": false
+    "ordered-imports": true,
+    "jsx-no-lambda": false
   }
 }


### PR DESCRIPTION
## Context & Motivations

- レート更新をした際に，ユーザーリストに更新した後の情報が反映されない
- レート更新後のランキングを見るにはページの再読込が必要で，無駄が多い

## Document

- [x] usersReducerにてaddContestRecordActionに対する挙動を追加
- [x] その他，プロフィール更新ページの挙動を修正