### PR TITLE
Gymなどのunratedなコンテストの結果を無視できていなかったバグを修正

### DIFF
--- a/src/utils/calculateMyRating.ts
+++ b/src/utils/calculateMyRating.ts
@@ -24,12 +24,14 @@ let ratingToSeeds: number[];
 export const calculateMyRating = async (
   contestData: ContestData
 ): Promise<{ nextRating: number; performance: number }> => {
+  contestants = new Array<Contestant>();
   await fetchContestants(contestData.contestID).catch((err) => {
     throw err;
   });
   if (contestants.length === 0) {
     throw new Error();
   }
+
   const index = contestData.rank;
   contestants.splice(index, 0, {
     handle: contestData.handle,
@@ -65,7 +67,6 @@ const fetchContestants = async (contestID: number) => {
   const json: any = await response.json();
   const results: any[] = json.result;
 
-  contestants = new Array<Contestant>();
   for (const result of results) {
     contestants.push({
       handle: result.handle,


### PR DESCRIPTION
## Context & Motivations

- #30 
- コンテスト結果を計算する際にコンテスタントの配列を適切なタイミングで初期化していなかったのが原因

## Document

- [x] コンテスタント配列を初期化するタイミングを修正