### PR TITLE
Persist language setting to localStorage (fix #61)

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,5 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import RootState from '../types/rootState';
 import AccountInfo from '../types/accountInfo';
@@ -27,4 +29,31 @@ export const useIsUpdatingRating = (): boolean => {
 
 export const useUsers = (): { [id: string]: UserProfile } => {
   return useSelector((state: RootState) => state.users);
+};
+
+const LANG_STORAGE_KEY = 'language';
+
+export const useLanguage = (): [boolean, (en: boolean) => void] => {
+  const queryParams = new URLSearchParams(useLocation().search);
+
+  const [isEnglish, setIsEnglishState] = useState<boolean>(() => {
+    const stored = localStorage.getItem(LANG_STORAGE_KEY);
+    return stored !== null ? stored === 'en' : false;
+  });
+
+  useEffect(() => {
+    const lang = queryParams.get('lang');
+    if (lang) {
+      const en = lang === 'en';
+      setIsEnglishState(en);
+      localStorage.setItem(LANG_STORAGE_KEY, en ? 'en' : 'ja');
+    }
+  }, []);
+
+  const setIsEnglish = useCallback((en: boolean) => {
+    setIsEnglishState(en);
+    localStorage.setItem(LANG_STORAGE_KEY, en ? 'en' : 'ja');
+  }, []);
+
+  return [isEnglish, setIsEnglish];
 };

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { Header } from 'semantic-ui-react';
+import { useLanguage } from '../hooks';
 
 const Contact = () => {
+  const [isEnglish] = useLanguage();
+
   return (
     <>
       <Header
         as="h2"
         content="Contact Me"
-        subheader="ご意見お待ちしております"
+        subheader={isEnglish ? 'Feel free to reach out!' : 'ご意見お待ちしております'}
       />
       <Header textAlign="left" as="h3" content="E-mail" />
       <p>sono888.gamestudio＠gmail.com(＠→@)</p>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -27,6 +27,7 @@ import RatingColoredName from '../components/RatingColoredName';
 import {
   useAccountInfo,
   useIsUpdatingRating,
+  useLanguage,
   useProfile,
   useUsers,
 } from '../hooks';
@@ -53,15 +54,12 @@ const ProfilePage: React.FC = () => {
   const isUpdatingRating = useIsUpdatingRating();
 
   const [certIdx, setCertIdx] = useState(-1);
-  const [isEnglish, setIsEnglish] = useState(false);
+  const [isEnglish, setIsEnglish] = useLanguage();
   const [debugLastUpdateTime, setDebugLastUpdateTime] = useState('');
 
   useEffect(() => {
     if (queryParams.get('cert')) {
       setCertIdx(Number(queryParams.get('cert')));
-    }
-    if (queryParams.get('lang')) {
-      setIsEnglish(queryParams.get('lang') === 'en');
     }
   }, []);
 

--- a/src/pages/StartPage.tsx
+++ b/src/pages/StartPage.tsx
@@ -1,25 +1,18 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { Link, useHistory, useLocation } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { Button, Header, Icon, List, Loader, Segment } from 'semantic-ui-react';
 import { login } from '../actions';
 import firebase from '../firebase';
-import { useAccountInfo } from '../hooks';
+import { useAccountInfo, useLanguage } from '../hooks';
 
 const StartPage: React.FC = () => {
   const history = useHistory();
-  const queryParams = new URLSearchParams(useLocation().search);
 
   const dispatch = useDispatch();
   const account = useAccountInfo();
   const [onLoging, setOnLoging] = useState(false);
-  const [isEnglish, setIsEnglish] = useState(false);
-
-  useEffect(() => {
-    if (queryParams.get('lang')) {
-      setIsEnglish(queryParams.get('lang') === 'en');
-    }
-  }, []);
+  const [isEnglish, setIsEnglish] = useLanguage();
 
   const onGoogleLogin = useCallback(() => {
     dispatch(

--- a/src/pages/UpdateProfilePage.tsx
+++ b/src/pages/UpdateProfilePage.tsx
@@ -1,15 +1,14 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { Button, Dimmer, Form, Header, Loader, Modal } from 'semantic-ui-react';
 import { updateProfile } from '../actions';
 import { fetchRealRating } from '../api/fetchRealRating';
-import { useAccountInfo, useProfile } from '../hooks';
+import { useAccountInfo, useLanguage, useProfile } from '../hooks';
 import getRatingColorStyle from '../utils/getRatingColorStyle';
 
 const UpdateProfilePage: React.FC = () => {
   const history = useHistory();
-  const queryParams = new URLSearchParams(useLocation().search);
 
   const dispatch = useDispatch();
   const account = useAccountInfo();
@@ -20,13 +19,7 @@ const UpdateProfilePage: React.FC = () => {
   const [modalOpen, setModalOpen] = useState(false);
   const [handleValidity, setHandleValidity] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
-  const [isEnglish, setIsEnglish] = useState(false);
-
-  useEffect(() => {
-    if (queryParams.get('lang')) {
-      setIsEnglish(queryParams.get('lang') === 'en');
-    }
-  }, []);
+  const [isEnglish, setIsEnglish] = useLanguage();
 
   const onButtonClick = useCallback(async () => {
     setIsLoading(true);


### PR DESCRIPTION
## Summary

- Add `useLanguage` hook that reads/writes language preference to localStorage
- Language selection persists across page reloads and navigation
- `?lang=en` query param still works and overwrites the stored value
- Apply shared language setting to all pages (StartPage, ProfilePage, UpdateProfilePage, Contact)

Closes #61

## Test plan

- [ ] Select EN on top page → navigate to other pages → language stays EN
- [ ] Reload page → language preference is retained
- [ ] Access with `?lang=en` → language switches to EN and persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)