### PR TITLE
Fix virtual rank bug in Educational/Div.3 rounds (fix #50)

### DIFF
--- a/src/__tests__/calculateRatingChange.ts
+++ b/src/__tests__/calculateRatingChange.ts
@@ -6,7 +6,7 @@ export default test('Validate rating change', () => {
     handle: 'hoge',
     rank: 162,
     rating: 2394,
-  }).then((newRating) => {
-    expect(newRating).toBe(2415);
+  }).then(({ nextRating }) => {
+    expect(nextRating).toBe(2415);
   });
 });

--- a/src/__tests__/calculateVirtualRank.validation.test.ts
+++ b/src/__tests__/calculateVirtualRank.validation.test.ts
@@ -44,14 +44,21 @@ async function buildTestContext(
   contestID: number,
   startTime: number
 ): Promise<TestContext> {
-  const [standingsRes, submissionsRes] = await Promise.all([
+  const [standingsRes, submissionsRes, ratingChangesRes] = await Promise.all([
     (global as any).fetch(`https://codeforces.com/api/contest.standings?contestId=${contestID}`),
     (global as any).fetch(`https://codeforces.com/api/user.status?handle=${handle}&count=500`),
+    (global as any).fetch(`https://codeforces.com/api/contest.ratingChanges?contestId=${contestID}`),
   ]);
-  const [standingsJson, submissionsJson] = await Promise.all([
+  const [standingsJson, submissionsJson, ratingChangesJson] = await Promise.all([
     standingsRes.json(),
     submissionsRes.json(),
+    ratingChangesRes.json(),
   ]);
+
+  const ratedHandles: Set<string> | null =
+    ratingChangesJson.status === 'OK' && ratingChangesJson.result.length > 0
+      ? new Set((ratingChangesJson.result as { handle: string }[]).map((r) => r.handle))
+      : null;
 
   const isICPC = standingsJson.result.contest.type === 'ICPC';
   const durationSeconds: number = standingsJson.result.contest.durationSeconds;
@@ -83,9 +90,11 @@ async function buildTestContext(
   }
   const solvedCount = solvedMap.size;
 
-  const rows = (standingsJson.result.rows as any[]).filter(
-    (r: any) => r.party.participantType === 'CONTESTANT' && !r.party.ghost
-  );
+  const rows = (standingsJson.result.rows as any[]).filter((r: any) => {
+    if (r.party.participantType !== 'CONTESTANT' || r.party.ghost) return false;
+    if (ratedHandles !== null) return ratedHandles.has(r.party.members[0]?.handle);
+    return true;
+  });
   let strict = 0, sameOrBetter = 0;
   for (const row of rows) {
     if (isICPC) {

--- a/src/__tests__/yaayaRankRegression.test.ts
+++ b/src/__tests__/yaayaRankRegression.test.ts
@@ -7,8 +7,9 @@
  *
  * 旧実装: contest.standings?showUnofficial=true でバーチャル参加者の行を直接取得しランク算出
  * 新実装: standings (official only) + user.status から独自計算
+ *         + contest.ratingChanges でレート対象者のみを母集団にフィルタ（fix #50）
  *
- * ■ 差異が生じる 2 つの原因
+ * ■ 差異が生じる原因
  *
  * 原因A: 旧実装のCF型スコア計算が「解いた問題数」による近似だった
  *   → Round 1073 (Div.2, CF型): 旧=641 / 新=518 (diff=-123)
@@ -19,15 +20,10 @@
  *   → コンテスト当日にバーチャル参加 → 旧レコード作成 → その後スタンディングが変化
  *   → 新実装は"現在の"スタンディングに基づく正確な値を返す
  *
- *   内訳:
- *     Round 1076 (Div.3, 2026-01-27 当日バーチャル): diff=-38
- *       → 旧レコード作成時はシステムテスト完了前。38名が後日不正解→除外された
- *     Edu 185 (2026-01-21): diff=-41
- *       → 同様に後日除外
- *     Edu 120 (2026-01-09): diff=+11
- *       → 後日システムテスト確定で11名が追加された
- *     Edu 128 (2026-01-06): diff=+10
- *       → 同様に後日追加
+ * 原因C: out-of-competition 参加者をランク計算から除外（fix #50）
+ *   → Educational Round / Div.3 では Div.1 参加者が out-of-competition として standings に含まれるが
+ *     ratingChanges には含まれない。旧実装はこれを含めてしまっていた。
+ *   → Edu 系は大幅にランクが下がる（母集団が大きく減るため）
  *
  * 実行: npm test -- --testPathPattern="yaayaRankRegression" --watchAll=false --runInBand
  * ※ CF API のレート制限のため --runInBand (シリアル実行) が必須
@@ -47,22 +43,24 @@ const CASES = [
   { contestID: 2191, startTime: 1768695300, oldRank: 641, expectedRank: 518,
     note: 'Round 1073 Div.2: 旧は解いた問題数近似 → 新はCFスコア式で正確' },
 
-  // ---- 差異あり: 原因B (スタンディングデータの変化) ----
-  { contestID: 2193, startTime: 1769508600, oldRank:  64, expectedRank:  26,
+  // ---- 差異あり: 原因B (スタンディングデータの変化) + 原因C (out-of-competition 除外) ----
+  { contestID: 2193, startTime: 1769508600, oldRank:  64, expectedRank:  25,
     note: 'Round 1076 Div.3: 当日バーチャル → システムテスト前のデータで旧レコード作成' },
-  { contestID: 2170, startTime: 1769002200, oldRank: 390, expectedRank: 349,
-    note: 'Edu 185: 後日除外参加者あり' },
-  { contestID: 1622, startTime: 1767960000, oldRank: 108, expectedRank: 119,
-    note: 'Edu 120: 後日確定参加者が追加' },
-  { contestID: 1680, startTime: 1767701400, oldRank:  87, expectedRank:  97,
-    note: 'Edu 128: 後日確定参加者が追加' },
+  { contestID: 2170, startTime: 1769002200, oldRank: 390, expectedRank: 239,
+    note: 'Edu 185: 後日除外参加者あり + Div.1 out-of-competition 除外' },
+  { contestID: 1622, startTime: 1767960000, oldRank: 108, expectedRank:  41,
+    note: 'Edu 120: 後日確定参加者が追加 + Div.1 out-of-competition 除外' },
+  { contestID: 1680, startTime: 1767701400, oldRank:  87, expectedRank:  43,
+    note: 'Edu 128: 後日確定参加者が追加 + Div.1 out-of-competition 除外' },
 
-  // ---- 差異なし: リグレッション確認 ----
-  { contestID: 1550, startTime: 1769430600, oldRank: 838, expectedRank: 838, note: 'Edu 111' },
+  // ---- Div.2 差異なし: リグレッション確認 ----
   { contestID: 1401, startTime: 1769081400, oldRank: 1022, expectedRank: 1022, note: 'Round 665 Div.2' },
   { contestID: 1422, startTime: 1768824000, oldRank: 122, expectedRank: 122, note: 'Round 675 Div.2' },
-  { contestID: 1569, startTime: 1768617000, oldRank: 302, expectedRank: 302, note: 'Edu 113' },
-  { contestID: 1574, startTime: 1768518300, oldRank: 135, expectedRank: 135, note: 'Edu 114' },
+
+  // ---- Educational: Div.1 out-of-competition 除外により変化 ----
+  { contestID: 1550, startTime: 1769430600, oldRank: 838, expectedRank: 628, note: 'Edu 111' },
+  { contestID: 1569, startTime: 1768617000, oldRank: 302, expectedRank: 164, note: 'Edu 113' },
+  { contestID: 1574, startTime: 1768518300, oldRank: 135, expectedRank:  62, note: 'Edu 114' },
 ];
 
 describe('yaaya 順位検証 (新実装の期待値で比較)', () => {

--- a/src/utils/calculateVirtualRank.ts
+++ b/src/utils/calculateVirtualRank.ts
@@ -134,18 +134,36 @@ export const calculateVirtualRank = async (data: {
     }
   }
 
-  // 5. 公式参加者の中で自分より上位の人数を数えてランクを算出
+  // 5. contest.ratingChanges で実際にレート対象だった参加者を取得
+  //    Educational Round 等で Div.1 が out-of-competition の場合、
+  //    standings には含まれるが ratingChanges には含まれない。
+  //    ratingChanges が存在する場合はそのハンドル集合を母集団とする。
+  const ratingChangesUrl = `https://codeforces.com/api/contest.ratingChanges?contestId=${contestID}`;
+  const ratingChangesRes = await fetch(ratingChangesUrl).catch(() => null);
+  let ratedHandles: Set<string> | null = null;
+  if (ratingChangesRes?.ok) {
+    const ratingChangesJson = await ratingChangesRes.json();
+    if (ratingChangesJson.status === 'OK' && ratingChangesJson.result.length > 0) {
+      ratedHandles = new Set(
+        (ratingChangesJson.result as { handle: string }[]).map((r) => r.handle)
+      );
+    }
+  }
+
+  // 6. 公式参加者の中で自分より上位の人数を数えてランクを算出
   let myRank = 1;
   for (const row of result.rows) {
     if (row.party.participantType !== 'CONTESTANT' || row.party.ghost) continue;
 
+    const handle = row.party.members[0]?.handle;
+    // ratedHandles が取得できている場合はレート対象者のみ比較
+    if (ratedHandles !== null && handle && !ratedHandles.has(handle)) continue;
+
     if (cfStyle) {
-      // CF 型: 合計スコアが高い人が上位（row.points は standings API が算出済み）
       if (row.points > myScore) {
         myRank++;
       }
     } else {
-      // ICPC 型: 正解数が多い、または同数でペナルティが少ない人が上位
       const theirSolved = row.problemResults.filter((p) => p.points > 0).length;
       if (
         theirSolved > mySolvedCount ||


### PR DESCRIPTION
## Summary

- Fetch `contest.ratingChanges` to get the rated participant pool
- Exclude out-of-competition contestants (e.g. Div.1 in Educational rounds) from virtual rank calculation
- Previously all `CONTESTANT` rows in standings were counted, inflating the rank by ~100–200 for Educational rounds

## Root cause

`contest.standings` includes Div.1 participants as `CONTESTANT` even in Educational rounds where they are out-of-competition. `contest.ratingChanges` only contains rated participants. The rank calculation was using the larger standings pool while the rating calculation (`calculateMyRating`) was using the smaller ratingChanges pool — causing a mismatch.

## Test results

All 58 tests pass. Educational round expected ranks updated to correct values (lower, Div.1 excluded).

Closes #50

## Test plan

- [x] Run `npm test` — 58 tests pass
- [ ] Verify Educational round virtual rank matches Div.2-only standings rank on CF

🤖 Generated with [Claude Code](https://claude.com/claude-code)