### PR TITLE
Add anytime-ui submodule for shared UI components (ref #66)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/anytime-ui"]
+	path = src/anytime-ui
+	url = https://github.com/sono8stream/anytime-ui.git

--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -1,21 +1,15 @@
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { useHistory, useLocation } from 'react-router-dom';
-import { Button, Container, Divider, Menu, Segment } from 'semantic-ui-react';
+import { useHistory } from 'react-router-dom';
+import { PageWrapper as SharedPageWrapper } from '../anytime-ui';
 import { changeAccountInfo, logout } from '../actions';
 import firebase from '../firebase';
 import { useAccountInfo } from '../hooks';
 
 const PageWrapper: React.FC<{ children: any }> = ({ children }) => {
   const history = useHistory();
-  const location = useLocation();
-
   const dispatch = useDispatch();
   const account = useAccountInfo();
-
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [location]);
 
   useEffect(() => {
     const unsubscribe = firebase.auth().onAuthStateChanged((user) => {
@@ -30,82 +24,18 @@ const PageWrapper: React.FC<{ children: any }> = ({ children }) => {
   }, [dispatch, history]);
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        minHeight: '100vh',
-        flexDirection: 'column',
-      }}
+    <SharedPageWrapper
+      appName="Codeforces Anytime"
+      accountId={account.id}
+      onNavigateHome={() => history.push('/')}
+      onNavigateContests={() => history.push('/contests')}
+      onNavigateRanking={() => history.push('/ranking')}
+      onNavigateProfile={() => history.push(`/users/${account.id}`)}
+      onLogout={() => dispatch(logout())}
+      onNavigateContact={() => history.push('/contact')}
     >
-      <Menu fixed="top" inverted={true} style={{ overflow: 'auto' }}>
-        <Menu.Item
-          header={true}
-          onClick={() => {
-            history.push('/');
-          }}
-        >
-          Codeforces Anytime
-        </Menu.Item>
-        <Menu.Item
-          onClick={() => {
-            history.push('/contests');
-          }}
-        >
-          Contests
-        </Menu.Item>
-        <Menu.Item
-          onClick={() => {
-            history.push('/ranking');
-          }}
-        >
-          Ranking
-        </Menu.Item>
-        {(() => {
-          if (account.id) {
-            return (
-              <>
-                <Menu.Item
-                  position="right"
-                  onClick={() => {
-                    history.push(`/users/${account.id}`);
-                  }}
-                >
-                  Profile
-                </Menu.Item>
-                <Menu.Item
-                  onClick={() => {
-                    dispatch(logout());
-                  }}
-                >
-                  Logout
-                </Menu.Item>
-              </>
-            );
-          } else {
-            return null;
-          }
-        })()}
-      </Menu>
-      <Container text={true} style={{ marginTop: '6em', flex: 1 }}>
-        {children}
-      </Container>
-      <div style={{ height: '5em' }} />
-      <Segment inverted={true} vertical={true} style={{ padding: '2em 0em' }}>
-        <Container textAlign="center">
-          <Button
-            basic={true}
-            inverted={true}
-            onClick={() => {
-              history.push('/contact');
-            }}
-          >
-            Contact Me
-          </Button>
-          <Divider inverted={true} />
-          <p>Copyright © 2019 sono. All rights reserved.</p>
-        </Container>
-      </Segment>
-    </div>
+      {children}
+    </SharedPageWrapper>
   );
 };
 

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -23,7 +23,13 @@ import {
 } from 'semantic-ui-react';
 import { fetchProfile, fetchUsers, updateContestRecords } from '../actions';
 import firebase from '../firebase';
-import RatingColoredName from '../components/RatingColoredName';
+import {
+  RatingColoredName,
+  getRatingColorStyle,
+  dateAndTimeStringFromSeconds,
+  monthStringFromTime,
+  calculateTimeTick,
+} from '../anytime-ui';
 import {
   useAccountInfo,
   useIsUpdatingRating,
@@ -32,12 +38,8 @@ import {
   useUsers,
 } from '../hooks';
 import UserProfile from '../types/userProfile';
-import { dateAndTimeStringFromSeconds } from '../utils/dateString';
-import { monthStringFromTime } from '../utils/dateString';
 import { getCertificate } from '../utils/getCertificate';
-import getRatingColorStyle from '../utils/getRatingColorStyle';
 import { getTwitterMessage } from '../utils/getTwitterMessage';
-import { calculateTimeTick } from '../utils/graphUtilities';
 
 const ProfilePage: React.FC = () => {
   const history = useHistory();

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -10,9 +10,8 @@ import {
   Table,
 } from 'semantic-ui-react';
 import { fetchUsers } from '../actions';
-import RatingColoredName from '../components/RatingColoredName';
+import { RatingColoredName, dateStringFromSeconds } from '../anytime-ui';
 import { useUsers } from '../hooks';
-import { dateStringFromSeconds } from '../utils/dateString';
 
 const RankingPage: React.FC = () => {
   const dispatch = useDispatch();


### PR DESCRIPTION
## Summary

- Create [sono8stream/anytime-ui](https://github.com/sono8stream/anytime-ui) submodule
- Add as git submodule at `src/anytime-ui`
- Migrate shared components/utilities to submodule:
  - `RatingColoredName` component
  - `PageWrapper` component (appName and nav callbacks as props instead of hardcoded)
  - `getRatingColorStyle` utility
  - `dateString` utilities
  - `graphUtilities` (calculateTimeTick)
- Update `ProfilePage` and `RankingPage` to import from `anytime-ui`

## Notes

The remaining files (`getCertificate`, `getTwitterMessage`, etc.) are more app-specific and left in place for now. AtCoder Anytime can clone with `--recurse-submodules` and reuse the same components.

Ref #66

## Test plan

- [ ] `npm run build` passes
- [ ] Nav bar still shows "Codeforces Anytime"
- [ ] Profile page renders correctly with rating colors and chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)